### PR TITLE
ci(release): Simplify dev build release process in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,20 @@ jobs:
       - name: Publish
         run: dotnet publish --configuration Release --output ./publish
 
-      # ✅ Compress all publish files into a single ZIP
       - name: Create ZIP Artifact
         run: |
           cd ./publish
           zip -r ../hello-world-app.zip .
           cd ..
 
-      # ✅ Upload artifact for later CI/CD steps
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: hello-world-app
           path: ./hello-world-app.zip
 
-      # ✅ Upload single zipped file to GitHub Release (for dev branch)
       - name: Upload to GitHub Release (dev-latest)
-        if: github.ref == 'refs/heads/dev'
+        if: startsWith(github.ref, 'refs/heads/dev')
         uses: softprops/action-gh-release@v2
         with:
           tag_name: dev-latest
@@ -60,13 +57,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      # ✅ Also create unique release (per run or PR)
-      - name: Upload to GitHub Release (dev-<PR or SHA>)
-        if: github.ref == 'refs/heads/dev'
+      - name: Upload to GitHub Release (dev-run)
+        if: startsWith(github.ref, 'refs/heads/dev')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: dev-${{ github.event.pull_request.number || github.run_number }}
-          name: Dev Build ${{ github.event.pull_request.number && format('PR #{0}', github.event.pull_request.number) || format('Run #{0}', github.run_number) }}
+          tag_name: dev-${{ github.run_number }}
+          name: Dev Build Run #${{ github.run_number }}
           files: ./hello-world-app.zip
           generate_release_notes: false
         env:


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow for creating development releases.

The changes include:
- Removing the logic that created releases based on pull request numbers, standardizing on using the `github.run_number` for all dev builds. This simplifies the release naming and tagging.
- Updating the conditional check from `github.ref == 'refs/heads/dev'` to `startsWith(github.ref, 'refs/heads/dev')` to correctly trigger for branches like `dev/feature-branch`.
- Removing redundant comments for a cleaner workflow file.